### PR TITLE
rpi-gpio.js: Failsafe match of cpuinfo

### DIFF
--- a/node_modules/rpi-gpio/rpi-gpio.js
+++ b/node_modules/rpi-gpio/rpi-gpio.js
@@ -277,8 +277,13 @@ function Gpio() {
 
             // Match the last 4 digits of the number following "Revision:"
             var match = data.match(/Revision\s*:\s*[0-9a-f]*([0-9a-f]{4})/);
-            var revisionNumber = parseInt(match[1], 16);
-            var pinVersion = (revisionNumber < 4) ? 'v1' : 'v2';
+            // Set default values which will be used if the regex don't match
+            var revisionNumber = 1;
+            var pinVersion = 'v2';
+            if (null !== match) {
+                revisionNumber = parseInt(match[1], 16);
+                pinVersion = (revisionNumber < 4) ? 'v1' : 'v2';
+            }
 
             debug(
                 'seen hardware revision %d; using pin mode %s',


### PR DESCRIPTION
Set default values and avoid the following error if match()
method returns null when checking the cpuinfo:

TypeError: Cannot read property '1' of null

Signed-off-by: Leon Anavi <leon@anavi.org>